### PR TITLE
Fixed import instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ levelup API wrapper for react-native AsyncStorage.
 This modules is a wrapper for our other module [asyncstorage-down](https://github.com/tradle/asyncstorage-down), which does all the real work and is implementing the leveldown API
 
 ```js
-var level = require('react-level')
+var level = require('react-native-level')
 var db = level('path/to/db', { /*...options...*/ })
 db.put('blah');
 db.batch([


### PR DESCRIPTION
Library was renamed from `react-level` to `react-native-level`. Have updated the README for new import steps.
